### PR TITLE
English grammar

### DIFF
--- a/eeschema/edit_component_in_schematic.cpp
+++ b/eeschema/edit_component_in_schematic.cpp
@@ -63,7 +63,7 @@ void SCH_EDIT_FRAME::EditComponentFieldText( SCH_FIELD* aField )
     if( fieldNdx == VALUE && part->IsPower() )
     {
         wxString msg = wxString::Format( _(
-            "%s is a power component and it's value cannot be modified!\n\n"
+            "%s is a power component and its value cannot be modified!\n\n"
             "You must create a new power component with the new value." ),
             GetChars( part->GetName() )
             );


### PR DESCRIPTION
The word "its" (referring to something belonging to "it") should not contain an apostrophe.  It is a possessive pronoun, like such words as "his", "hers", "mine", and "yours", none of which contain apostrophes.
