### PR TITLE
without this, script will hang several times

### DIFF
--- a/scripts/kicad-install.sh
+++ b/scripts/kicad-install.sh
@@ -125,7 +125,7 @@ install_prerequisites()
 
         for p in ${prerequisite_list}
         do
-            sudo apt-get install $p || exit 1
+            sudo apt-get install -y $p || exit 1
         done
 
         # Only install the scripting prerequisites if required.
@@ -139,7 +139,7 @@ install_prerequisites()
 
             for sp in ${scripting_prerequisites}
             do
-                sudo apt-get install $sp || exit 1
+                sudo apt-get install -y $sp || exit 1
             done
         fi
 


### PR DESCRIPTION
installing kicad on a system using apt-get takes hours, starting with installing many dependancies.  Leaving out the -y causes apt-get to stop many times during the process asking [Y/n] when the user already decided to install kicad.