### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/3d-viewer/x3dmodelparser.cpp
+++ b/3d-viewer/x3dmodelparser.cpp
@@ -92,7 +92,7 @@ bool X3D_MODEL_PARSER::Load( const wxString& aFilename )
 
     for( NODE_LIST::iterator node_it = transforms.begin();
          node_it != transforms.end();
-         node_it++ )
+         ++node_it )
     {
         m_model.reset( new S3D_MESH() );
         childs.push_back( m_model );
@@ -164,7 +164,7 @@ void X3D_MODEL_PARSER::readTransform( wxXmlNode* aTransformNode )
 
     for( NODE_LIST::iterator node = childnodes.begin();
          node != childnodes.end();
-         node++ )
+         ++node )
     {
         readMaterial( *node );
     }
@@ -181,7 +181,7 @@ void X3D_MODEL_PARSER::readTransform( wxXmlNode* aTransformNode )
 
     for( NODE_LIST::iterator node = childnodes.begin();
          node != childnodes.end();
-         node++ )
+         ++node )
     {
         readIndexedFaceSet( *node, properties );
     }
@@ -282,7 +282,7 @@ void X3D_MODEL_PARSER::readMaterial( wxXmlNode* aMatNode )
         wxString vrml_material;
         PROPERTY_MAP::const_iterator p = ++properties.begin();    // skip DEF
 
-        for( ; p != properties.end(); p++ )
+        for( ; p != properties.end(); ++p )
         {
             vrml_material.Append( p->first + wxT( " " ) + p->second + wxT( "\n" ) );
         }

--- a/common/common_plotGERBER_functions.cpp
+++ b/common/common_plotGERBER_functions.cpp
@@ -230,7 +230,7 @@ std::vector<APERTURE>::iterator GERBER_PLOTTER::getAperture( const wxSize&      
         if( (tool->Type == type) && (tool->Size == size) )
             return tool;
 
-        tool++;
+        ++tool;
     }
 
     // Allocate a new aperture
@@ -266,7 +266,7 @@ void GERBER_PLOTTER::writeApertureList()
 
     // Init
     for( std::vector<APERTURE>::iterator tool = apertures.begin();
-         tool != apertures.end(); tool++ )
+         tool != apertures.end(); ++tool )
     {
         // apertude sizes are in inch or mm, regardless the
         // coordinates format

--- a/eeschema/class_libentry.cpp
+++ b/eeschema/class_libentry.cpp
@@ -537,7 +537,7 @@ void LIB_PART::RemoveDrawItem( LIB_ITEM* aItem, EDA_DRAW_PANEL* aPanel, wxDC* aD
 
     LIB_ITEMS::iterator i;
 
-    for( i = drawings.begin(); i < drawings.end(); i++ )
+    for( i = drawings.begin(); i != drawings.end(); /* incremented in the content of loop */ )
     {
         if( *i == aItem )
         {
@@ -545,10 +545,12 @@ void LIB_PART::RemoveDrawItem( LIB_ITEM* aItem, EDA_DRAW_PANEL* aPanel, wxDC* aD
                 aItem->Draw( aPanel, aDc, wxPoint( 0, 0 ), UNSPECIFIED_COLOR,
                              g_XorMode, NULL, DefaultTransform );
 
-            drawings.erase( i );
+            i = drawings.erase( i );
             SetModified();
             break;
         }
+        else
+            ++i;
     }
 }
 
@@ -1486,7 +1488,7 @@ void LIB_PART::DeleteSelectedItems()
         }
 
         if( !item->IsSelected() )
-            item++;
+            ++item;
         else
             item = drawings.erase( item );
     }
@@ -1624,7 +1626,7 @@ void LIB_PART::SetUnitCount( int aCount )
             if( i->m_Unit > aCount )
                 i = drawings.erase( i );
             else
-                i++;
+                ++i;
         }
     }
     else
@@ -1689,7 +1691,7 @@ void LIB_PART::SetConversion( bool aSetConvert )
             if( i->m_Convert > 1 )
                 i = drawings.erase( i );
             else
-                i++;
+                ++i;
         }
     }
 }
@@ -1701,7 +1703,7 @@ wxArrayString LIB_PART::GetAliasNames( bool aIncludeRoot ) const
 
     LIB_ALIASES::const_iterator it;
 
-    for( it=m_aliases.begin();  it<m_aliases.end();  ++it )
+    for( it=m_aliases.begin();  it != m_aliases.end();  ++it )
     {
         if( !aIncludeRoot && (*it)->IsRoot() )
             continue;
@@ -1748,7 +1750,7 @@ void LIB_PART::SetAliases( const wxArrayString& aAliasList )
     // Remove names in the current component that are not in the new alias list.
     LIB_ALIASES::iterator it;
 
-    for( it = m_aliases.begin(); it < m_aliases.end(); it++ )
+    for( it = m_aliases.begin(); it != m_aliases.end(); ++it )
     {
         int index = aAliasList.Index( (*it)->GetName(), false );
 
@@ -1770,7 +1772,7 @@ void LIB_PART::RemoveAlias( const wxString& aName )
 
     LIB_ALIASES::iterator it;
 
-    for( it = m_aliases.begin(); it < m_aliases.end(); it++ )
+    for( it = m_aliases.begin(); it != m_aliases.end(); it++ )
     {
         if( Cmp_KEEPCASE( aName, (*it)->GetName() ) == 0 )
         {

--- a/eeschema/class_library.cpp
+++ b/eeschema/class_library.cpp
@@ -96,7 +96,7 @@ PART_LIB::~PART_LIB()
 
 void PART_LIB::GetEntryNames( wxArrayString& aNames, bool aSort, bool aMakeUpperCase )
 {
-    for( LIB_ALIAS_MAP::iterator it = m_amap.begin();  it!=m_amap.end();  it++ )
+    for( LIB_ALIAS_MAP::iterator it = m_amap.begin();  it!=m_amap.end();  ++it )
     {
         if( aMakeUpperCase )
         {
@@ -117,7 +117,7 @@ void PART_LIB::GetEntryNames( wxArrayString& aNames, bool aSort, bool aMakeUpper
 
 void PART_LIB::GetEntryTypePowerNames( wxArrayString& aNames, bool aSort, bool aMakeUpperCase )
 {
-    for( LIB_ALIAS_MAP::iterator it = m_amap.begin();  it!=m_amap.end();  it++ )
+    for( LIB_ALIAS_MAP::iterator it = m_amap.begin();  it!=m_amap.end();  ++it )
     {
         LIB_ALIAS* alias = it->second;
         LIB_PART* root = alias->GetPart();
@@ -195,7 +195,7 @@ void PART_LIB::SearchEntryNames( wxArrayString& aNames, const wxRegEx& aRe, bool
 
     LIB_ALIAS_MAP::iterator it;
 
-    for( it = m_amap.begin();  it!=m_amap.end();  it++ )
+    for( it = m_amap.begin();  it!=m_amap.end();  ++it )
     {
         if( aRe.Matches( it->second->GetKeyWords() ) )
             aNames.Add( it->first );
@@ -265,7 +265,7 @@ LIB_PART* PART_LIB::FindPart( const wxString& aName )
 bool PART_LIB::HasPowerParts()
 {
     // return true if at least one power part is found in lib
-    for( LIB_ALIAS_MAP::iterator it = m_amap.begin();  it!=m_amap.end();  it++ )
+    for( LIB_ALIAS_MAP::iterator it = m_amap.begin();  it!=m_amap.end();  ++it )
     {
         LIB_ALIAS* alias = it->second;
         LIB_PART* root = alias->GetPart();
@@ -373,7 +373,7 @@ LIB_ALIAS* PART_LIB::RemoveEntry( LIB_ALIAS* aEntry )
         if( m_amap.size() > 1 )
         {
             LIB_ALIAS_MAP::iterator next = it;
-            next++;
+            ++next;
 
             if( next == m_amap.end() )
                 next = m_amap.begin();
@@ -430,7 +430,7 @@ LIB_ALIAS* PART_LIB::GetNextEntry( const wxString& aName )
 
     LIB_ALIAS_MAP::iterator it = m_amap.find( aName );
 
-    it++;
+    ++it;
 
     if( it == m_amap.end() )
         it = m_amap.begin();
@@ -736,7 +736,7 @@ bool PART_LIB::Save( OUTPUTFORMATTER& aFormatter )
     {
         SaveHeader( aFormatter );
 
-        for( LIB_ALIAS_MAP::iterator it=m_amap.begin();  it!=m_amap.end();  it++ )
+        for( LIB_ALIAS_MAP::iterator it=m_amap.begin();  it!=m_amap.end();  ++it )
         {
             if( !it->second->IsRoot() )
                 continue;
@@ -763,7 +763,7 @@ bool PART_LIB::SaveDocs( OUTPUTFORMATTER& aFormatter )
     {
         aFormatter.Print( 0, "%s\n", DOCFILE_IDENT );
 
-        for( LIB_ALIAS_MAP::iterator it=m_amap.begin();  it!=m_amap.end();  it++ )
+        for( LIB_ALIAS_MAP::iterator it=m_amap.begin();  it!=m_amap.end();  ++it )
         {
             if( !it->second->SaveDoc( aFormatter ) )
                 success = false;

--- a/eeschema/netlist.cpp
+++ b/eeschema/netlist.cpp
@@ -134,7 +134,7 @@ void NETLIST_OBJECT_LIST::Clear()
 {
     NETLIST_OBJECTS::iterator iter;
 
-    for( iter = begin(); iter != end(); iter++ )
+    for( iter = begin(); iter != end(); ++iter )
     {
         NETLIST_OBJECT* item = *iter;
         delete item;

--- a/eeschema/sch_sheet.cpp
+++ b/eeschema/sch_sheet.cpp
@@ -501,7 +501,7 @@ void SCH_SHEET::CleanupSheet()
         }
 
         if( HLabel == NULL )   // Hlabel not found: delete sheet label.
-            m_pins.erase( i );
+            i = m_pins.erase( i );
         else
             ++i;
     }

--- a/pcbnew/autorouter/spread_footprints.cpp
+++ b/pcbnew/autorouter/spread_footprints.cpp
@@ -129,7 +129,7 @@ void spreadRectangles( CRectPlacement& aPlacementArea,
         it->x   = r.x;
         it->y   = r.y;
 
-        it++;
+        ++it;
     }
 }
 

--- a/pcbnew/pcbnew_config.cpp
+++ b/pcbnew/pcbnew_config.cpp
@@ -463,7 +463,7 @@ void PCB_EDIT_FRAME::SaveMacros()
 
         for( std::list<MACROS_RECORD>::reverse_iterator i = m_Macros[number].m_Record.rbegin();
              i != m_Macros[number].m_Record.rend();
-             i++ )
+             ++i )
         {
             hkStr.Printf( wxT( "%d" ), i->m_HotkeyCode );
             xStr.Printf( wxT( "%d" ), i->m_Position.x );

--- a/pcbnew/router/pns_shove.cpp
+++ b/pcbnew/router/pns_shove.cpp
@@ -819,7 +819,7 @@ void PNS_SHOVE::unwindStack( PNS_SEGMENT *aSeg )
         if( i->ContainsSegment( aSeg ) )
             i = m_lineStack.erase( i );
         else
-            i++;
+            ++i;
     }
 
     for( std::vector<PNS_LINE>::iterator i = m_optimizerQueue.begin(); i != m_optimizerQueue.end() ; )
@@ -827,7 +827,7 @@ void PNS_SHOVE::unwindStack( PNS_SEGMENT *aSeg )
         if( i->ContainsSegment( aSeg ) )
             i = m_optimizerQueue.erase( i );
         else
-            i++;
+            ++i;
     }
 }
 
@@ -890,7 +890,7 @@ void PNS_SHOVE::popLine( )
         }
 
         if( !found )
-            i++;
+            ++i;
     }
 
     m_lineStack.pop_back();

--- a/polygon/clipper.cpp
+++ b/polygon/clipper.cpp
@@ -2670,14 +2670,14 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
       if (dir == dLeftToRight)
       {
           maxIt = m_Maxima.begin();
-          while (maxIt != m_Maxima.end() && *maxIt <= horzEdge->Bot.X) maxIt++;
+          while (maxIt != m_Maxima.end() && *maxIt <= horzEdge->Bot.X) ++maxIt;
           if (maxIt != m_Maxima.end() && *maxIt >= eLastHorz->Top.X)
               maxIt = m_Maxima.end();
       }
       else
       {
           maxRit = m_Maxima.rbegin();
-          while (maxRit != m_Maxima.rend() && *maxRit > horzEdge->Bot.X) maxRit++;
+          while (maxRit != m_Maxima.rend() && *maxRit > horzEdge->Bot.X) ++maxRit;
           if (maxRit != m_Maxima.rend() && *maxRit <= eLastHorz->Top.X)
               maxRit = m_Maxima.rend();
       }
@@ -2704,7 +2704,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
                 {
                   if (horzEdge->OutIdx >= 0 && !IsOpen)
                     AddOutPt(horzEdge, IntPoint(*maxIt, horzEdge->Bot.Y));
-                  maxIt++;
+                  ++maxIt;
                 }
             }
             else
@@ -2713,7 +2713,7 @@ void Clipper::ProcessHorizontal(TEdge *horzEdge)
                 {
                   if (horzEdge->OutIdx >= 0 && !IsOpen)
                     AddOutPt(horzEdge, IntPoint(*maxRit, horzEdge->Bot.Y));
-                  maxRit++;
+                  ++maxRit;
                 }
             }
         };

--- a/utils/idftools/idf_cylinder.cpp
+++ b/utils/idftools/idf_cylinder.cpp
@@ -579,7 +579,6 @@ void make_hcyl( bool inch, bool axial, double dia, double length,
     fprintf( fp, ".END_ELECTRICAL\n" );
     fclose( fp );
     return;
-    return;
 }
 
 void writeAxialCyl( FILE* fp, bool inch, double dia, double length,

--- a/utils/idftools/idf_helpers.cpp
+++ b/utils/idftools/idf_helpers.cpp
@@ -83,7 +83,7 @@ bool IDF3::GetIDFString( const std::string& aLine, std::string& aIDFString,
     if( idx < 0 || idx >= len )
         return false;
 
-    while( isspace( aLine[idx] ) && idx < len ) ++idx;
+    while( idx < len && isspace( aLine[idx] ) ) ++idx;
 
     if( idx == len )
     {
@@ -95,7 +95,7 @@ bool IDF3::GetIDFString( const std::string& aLine, std::string& aIDFString,
     {
         hasQuotes = true;
         ++idx;
-        while( aLine[idx] != '"' && idx < len )
+        while( idx < len && aLine[idx] != '"' )
             ostr << aLine[idx++];
 
         if( idx == len )
@@ -112,7 +112,7 @@ bool IDF3::GetIDFString( const std::string& aLine, std::string& aIDFString,
     {
         hasQuotes = false;
 
-        while( !isspace( aLine[idx] ) && idx < len )
+        while( idx < len && !isspace( aLine[idx] ) )
             ostr << aLine[idx++];
 
     }


### PR DESCRIPTION
Those like "Prefer prefix ++/-- operators for non-primitive types"
[utils/idftools/idf_helpers.cpp:86]: (style) Array index 'idx' is used before limits check.
[utils/idftools/idf_helpers.cpp:98]: (style) Array index 'idx' is used before limits check.
[utils/idftools/idf_helpers.cpp:115]: (style) Array index 'idx' is used before limits check.
[eeschema/sch_sheet.cpp:484] -> [eeschema/sch_sheet.cpp:504]: (error) Iterator 'i' used after element has been erased
[utils/idftools/idf_cylinder.cpp:582]: (style) Consecutive return, break, continue, goto or throw statements are unnecessary