### PR TITLE
typo in cobject2d.h

### DIFF
--- a/3d-viewer/3d_rendering/3d_render_raytracing/shapes2D/cobject2d.h
+++ b/3d-viewer/3d_rendering/3d_render_raytracing/shapes2D/cobject2d.h
@@ -111,7 +111,7 @@ public:
 
     /**
      * Function IsBBoxInside
-     * @brief Tests if the bounding is out, intersects or is complety inside
+     * @brief Tests if the bounding is out, intersects or is completely inside
      * @return INTERSECTION_RESULT
      */
     virtual INTERSECTION_RESULT IsBBoxInside( const CBBOX2D &aBBox ) const = 0;


### PR DESCRIPTION
A minor typo 'complety' -> 'completely' if I got it correctly